### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 ## 项目背景
 MCP_Agent:RE是一个用于从TAPD平台获取需求和缺陷数据的Python项目，旨在为AI客户端提供数据支持。
 
+<a href="https://glama.ai/mcp/servers/@OneCuriousLearner/MCPAgentRE">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@OneCuriousLearner/MCPAgentRE/badge" alt="TAPD Data Fetcher MCP server" />
+</a>
+
 ## 项目结构
 - `knowledge_documents`：包含项目相关的知识文档
 - `tapd_data_fetcher.py`：包含从TAPD API获取需求和缺陷数据的逻辑


### PR DESCRIPTION
This PR adds a badge for the [TAPD Data Fetcher](https://glama.ai/mcp/servers/@OneCuriousLearner/MCPAgentRE) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@OneCuriousLearner/MCPAgentRE">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@OneCuriousLearner/MCPAgentRE/badge" alt="TAPD Data Fetcher MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.